### PR TITLE
Added correct links to vqa datasets

### DIFF
--- a/data/download.sh
+++ b/data/download.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 # questions
-wget http://visualqa.org/data/mscoco/vqa/v2_Questions_Train_mscoco.zip http://visualqa.org/data/mscoco/vqa/v2_Questions_Val_mscoco.zip http://visualqa.org/data/mscoco/vqa/v2_Questions_Test_mscoco.zip
+wget https://s3.amazonaws.com/cvmlp/vqa/mscoco/vqa/v2_Questions_Train_mscoco.zip https://s3.amazonaws.com/cvmlp/vqa/mscoco/vqa/v2_Questions_Val_mscoco.zip https://s3.amazonaws.com/cvmlp/vqa/mscoco/vqa/v2_Questions_Test_mscoco.zip
 
 # answers
-wget http://visualqa.org/data/mscoco/vqa/v2_Annotations_Train_mscoco.zip http://visualqa.org/data/mscoco/vqa/v2_Annotations_Val_mscoco.zip
+wget https://s3.amazonaws.com/cvmlp/vqa/mscoco/vqa/v2_Annotations_Train_mscoco.zip https://s3.amazonaws.com/cvmlp/vqa/mscoco/vqa/v2_Annotations_Val_mscoco.zip
 
 # balanced pairs
-wget http://visualqa.org/data/mscoco/vqa/v2_Complementary_Pairs_Train_mscoco.zip http://visualqa.org/data/mscoco/vqa/v2_Complementary_Pairs_Val_mscoco.zip
+wget https://s3.amazonaws.com/cvmlp/vqa/mscoco/vqa/v2_Complementary_Pairs_Train_mscoco.zip https://s3.amazonaws.com/cvmlp/vqa/mscoco/vqa/v2_Complementary_Pairs_Val_mscoco.zip
 
 # bottom up features (https://github.com/peteanderson80/bottom-up-attention)
 wget https://imagecaption.blob.core.windows.net/imagecaption/trainval.zip https://imagecaption.blob.core.windows.net/imagecaption/test2015.zip


### PR DESCRIPTION
Thank you for the repository.

The download links for vqa2 dataset have changed. I have added correct links in `data/download.sh`